### PR TITLE
Add AuraKit to Skills & Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Only repositories with **1,000+ stars** are listed. PRs are always welcome!
 | [Ceeon/videocut-skills](https://github.com/Ceeon/videocut-skills) | ![](https://img.shields.io/github/stars/Ceeon/videocut-skills?style=flat-square&logo=github) | Video editing agent skill for Claude Code |
 | [Lum1104/Understand-Anything](https://github.com/Lum1104/Understand-Anything) | ![](https://img.shields.io/github/stars/Lum1104/Understand-Anything?style=flat-square&logo=github) | Turn any codebase into an interactive knowledge graph via Claude Code skills |
 
+| [smorky850612/AuraKit](https://github.com/smorky850612/Aurakit) | ![](https://img.shields.io/github/stars/smorky850612/Aurakit?style=flat-square&logo=github) | All-in-one fullstack Claude Code skill: 46 modes, 23 sub-agents, 6-layer security (OWASP+), 10 hooks, 8 languages, ~55% token savings |
 ## Agent Orchestration
 
 | Repository | Stars | Description |


### PR DESCRIPTION
## Summary

Adds [AuraKit](https://github.com/smorky850612/Aurakit) to the **Skills & Plugins** section.

## About AuraKit

An all-in-one fullstack Claude Code skill — one `/aura` command for the entire development lifecycle.

| Feature | Details |
|---------|---------|
| **Modes** | 46 (BUILD, FIX, CLEAN, DEPLOY, REVIEW, TDD, QA, DEBUG, PAYMENT…) |
| **Sub-agents** | 23 (Scout, Builder, Reviewer, SecurityAgent, TestRunner…) |
| **Security** | 6-layer OWASP+ (bash-guard, secret scanning, SQL injection prevention) |
| **Token savings** | ~55% via tiered model routing (Haiku/Sonnet/Opus) |
| **Languages** | TypeScript, Python, Go, Java, Rust, Kotlin, C++, Swift |
| **Platforms** | Claude Code, Codex, Cursor, Manus, Windsurf |

```bash
npx @smorky85/aurakit
```

[GitHub](https://github.com/smorky850612/Aurakit) · [npm](https://www.npmjs.com/package/@smorky85/aurakit)