### PR TITLE
Add cctally to Monitoring & Analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ Only repositories with **1,000+ stars** are listed. PRs are always welcome!
 | [nguyenphutrong/quotio](https://github.com/nguyenphutrong/quotio) | ![](https://img.shields.io/github/stars/nguyenphutrong/quotio?style=flat-square&logo=github) | macOS menu bar app unifying Claude, Gemini, OpenAI, Qwen subscriptions with quota tracking |
 | [disler/claude-code-hooks-multi-agent-observability](https://github.com/disler/claude-code-hooks-multi-agent-observability) | ![](https://img.shields.io/github/stars/disler/claude-code-hooks-multi-agent-observability?style=flat-square&logo=github) | Real-time monitoring for Claude Code agents through hook event tracking |
 | [matt1398/claude-devtools](https://github.com/matt1398/claude-devtools) | ![](https://img.shields.io/github/stars/matt1398/claude-devtools?style=flat-square&logo=github) | DevTools for Claude Code: inspect session logs, tool calls, token usage, subagents |
+| [omrikais/cctally](https://github.com/omrikais/cctally) | ![](https://img.shields.io/github/stars/omrikais/cctally?style=flat-square&logo=github) | Weekly $-per-1% trend tracker for Claude Code subscription with local dashboard, TUI, forecasts, and threshold alerts |
 
 ## Learning & Reference
 


### PR DESCRIPTION
Adds [cctally](https://github.com/omrikais/cctally) to the Monitoring & Analytics section.

cctally tracks Claude Code subscription usage as a weekly \$-per-1% trend, with a local web dashboard, terminal UI, forecasts, and threshold alerts. It complements the existing entries (ccusage, sniffly, Claude-Code-Usage-Monitor) by focusing on the subscription-quota dimension rather than raw token cost — local-only, no telemetry, Apache-2.0.