### PR TITLE
Add ianymu/claude-verify-before-stop (Stop hook against 'lies of completion')

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Only repositories with **1,000+ stars** are listed. PRs are always welcome!
 | [addyosmani/agent-skills](https://github.com/addyosmani/agent-skills) | ![](https://img.shields.io/github/stars/addyosmani/agent-skills?style=flat-square&logo=github) | Production-grade engineering skills for AI coding agents from Addy Osmani |
 | [K-Dense-AI/scientific-agent-skills](https://github.com/K-Dense-AI/scientific-agent-skills) | ![](https://img.shields.io/github/stars/K-Dense-AI/scientific-agent-skills?style=flat-square&logo=github) | Ready-to-use Agent Skills for research, science, engineering, finance, and writing |
 | [nizos/tdd-guard](https://github.com/nizos/tdd-guard) | ![](https://img.shields.io/github/stars/nizos/tdd-guard?style=flat-square&logo=github) | TDD enforcement for Claude Code via hooks blocking non-test-driven edits |
+| [ianymu/claude-verify-before-stop](https://github.com/ianymu/claude-verify-before-stop) | ![](https://img.shields.io/github/stars/ianymu/claude-verify-before-stop?style=flat-square&logo=github) | Stop hook that blocks session end until verification is logged — kills "lies of completion" |
 
 ## Agent Orchestration
 


### PR DESCRIPTION
Adding a small open-source Stop hook for Claude Code: **[claude-verify-before-stop](https://github.com/ianymu/claude-verify-before-stop)**.

**What it does**
A Stop hook that blocks Claude Code from ending the session if files changed but no verification was logged in the last 5 minutes. Forces the model to either prove it verified (running tests, curl, playwright, psql, etc.) or admit it didn't — stops the *"All tests passing ✅"* + production-breaks regression cycle.

**Why it fits this list**
- Pure bash + python3 stdlib — zero dependencies, no install step beyond curl.
- MIT licensed, sits in Skills & Plugins alongside tdd-guard (same category: hook-based behavioral guardrails).
- Tags: `claude-code`, `hooks`, `stop-hook`, `verification`, `productivity`.

Placed right after `tdd-guard` since both are hook-based enforcement tools. Happy to move or tweak the description — thanks for maintaining this list.