### PR TITLE
Add handoff — cross-agent task dispatcher for Claude Code / Codex

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ Only repositories with **1,000+ stars** are listed. PRs are always welcome!
 | [langchain-ai/open-swe](https://github.com/langchain-ai/open-swe) | ![](https://img.shields.io/github/stars/langchain-ai/open-swe?style=flat-square&logo=github) | LangChain's open-source asynchronous coding agent for long-running tasks |
 | [agent-infra/sandbox](https://github.com/agent-infra/sandbox) | ![](https://img.shields.io/github/stars/agent-infra/sandbox?style=flat-square&logo=github) | All-in-one Docker sandbox combining browser, shell, file, MCP, and VSCode for agents |
 | [kubernetes-sigs/agent-sandbox](https://github.com/kubernetes-sigs/agent-sandbox) | ![](https://img.shields.io/github/stars/kubernetes-sigs/agent-sandbox?style=flat-square&logo=github) | Kubernetes-native isolated, stateful workloads for AI agent runtimes |
+| [dazuiba/handoff](https://github.com/dazuiba/handoff) | ![](https://img.shields.io/github/stars/dazuiba/handoff?style=flat-square&logo=github) | Delegate tasks to DeepSeek V4, Codex, or Opus right inside your Claude Code session |
 
 ## GUI & IDE
 


### PR DESCRIPTION
## What is handoff?

[handoff](https://github.com/dazuiba/handoff) is a skill/subagent (backed by handoff-cli) that lets you delegate tasks to DeepSeek V4, Codex, or Claude Opus right inside your Claude Code / Codex session — without switching tools or losing context.

- Runs the delegated task in the background; your session never blocks
- Result comes back automatically when the task finishes
- Supports parallel tasks and resuming past sessions

## Why it belongs here

handoff is an agent orchestration skill for Claude Code that routes work to other agents without context loss.

## Links

- GitHub: https://github.com/dazuiba/handoff
- Install: `uv tool install handoff-cli && handoff init`
